### PR TITLE
Use projected content

### DIFF
--- a/src/app/embedded/awesome/awesome.component.ts
+++ b/src/app/embedded/awesome/awesome.component.ts
@@ -7,7 +7,7 @@ import { Component, ElementRef, OnInit } from '@angular/core';
 @Component({
   /* tslint:disable component-selector */
   selector: 'awesome',
-  template: '<span></span>'
+  template: '<ng-content></ng-content>'
 })
 export class AwesomeComponent implements OnInit {
 
@@ -18,12 +18,8 @@ export class AwesomeComponent implements OnInit {
    }
 
   ngOnInit() {
+    let content = this.hostElement.innerHTML;
 
-    // The `awesomeContent` property is set by the DocViewer when it builds this component.
-    // It is the original innerHTML of the host element.
-    let content: string = this.hostElement['awesomeContent'];
-
-    // Manipulate that content:
     // Follow every "the" or "The" with "awesome"
     content = content.replace(/([Tt]he) /g, '$1 awesome ');
 
@@ -31,9 +27,7 @@ export class AwesomeComponent implements OnInit {
     content = content.replace(/(The) /g, '<b>OMG!</b> $1 ');
 
     // stuff it into the component's element
-    // **Security:** `awesomeContent` is provided by Development Team
-    // and is considered safe.
+    // **Security:** manipulates the innerHTML from safe source in a safe way.
     this.hostElement.innerHTML = content;
-
   }
 }

--- a/src/app/embedded/code/code-example.component.ts
+++ b/src/app/embedded/code/code-example.component.ts
@@ -17,49 +17,43 @@ import { getBoolFromAttribute } from 'app/shared/attribute-utils';
   selector: 'code-example',
   template: `
     <header *ngIf="title">{{title}}</header>
-    <aio-code [ngClass]="classes" [code]="code"
-    [language]="language" [linenums]="linenums"
-    [path]="path" [region]="region"
-    [hideCopy]="hideCopy" [title]="title"></aio-code>
+    <aio-code
+      [ngClass]="classes"
+      [hideCopy]="hideCopy"
+      [language]="language"
+      [linenums]="linenums"
+      [path]="path"
+      [region]="region"
+      [title]="title">
+      <ng-content></ng-content>
+    </aio-code>
   `
 })
 export class CodeExampleComponent implements OnInit {
 
   classes: {};
-  code: string;
+  hideCopy: boolean;
   language: string;
   linenums: string;
   path: string;
   region: string;
   title: string;
-  hideCopy: boolean;
 
-  @HostBinding('class.avoidFile')
-  isAvoid = false;
+  @HostBinding('class.avoid') isAvoid = false;
 
-  constructor(private elementRef: ElementRef) {
+  constructor(private elementRef: ElementRef) {  }
+
+  ngOnInit() {
     const element: HTMLElement = this.elementRef.nativeElement;
-
-    this.language = element.getAttribute('language') || '';
-    this.linenums = element.getAttribute('linenums');
-    this.path = element.getAttribute('path') || '';
-    this.region = element.getAttribute('region') || '';
-    this.title = element.getAttribute('title') || '';
-    // Now remove the title attribute to prevent unwanted tooltip popups when hovering over the code.
+    // Remove the title attribute to prevent unwanted tooltip popups when hovering over the code.
     element.removeAttribute('title');
 
-    this.isAvoid = this.path.indexOf('.avoid.') !== -1;
+    this.isAvoid = (this.path || '').indexOf('.avoid.') !== -1;
     this.hideCopy = this.isAvoid || getBoolFromAttribute(element, ['hidecopy', 'hide-copy']);
 
     this.classes = {
       'headed-code': !!this.title,
       'simple-code': !this.title,
     };
-  }
-
-  ngOnInit() {
-    // The `codeExampleContent` property is set by the DocViewer when it builds this component.
-    // It is the original innerHTML of the host element.
-    this.code = this.elementRef.nativeElement.codeExampleContent;
   }
 }

--- a/src/app/embedded/code/code-tabs.component.ts
+++ b/src/app/embedded/code/code-tabs.component.ts
@@ -1,8 +1,14 @@
-import { Component, ElementRef, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { MatTabGroup } from '@angular/material/tabs';
+
+
+import { getBoolFromAttribute } from 'app/shared/attribute-utils';
 
 export interface TabInfo {
   class: string;
   code: string;
+  hideCopy: boolean;
+  isAvoid: boolean;
   language: string;
   linenums: any;
   path: string;
@@ -21,56 +27,78 @@ export interface TabInfo {
   /* tslint:disable component-selector */
   selector: 'code-tabs',
   template: `
-    <mat-tab-group class="code-tab-group" disableRipple>
-      <mat-tab style="overflow-y: hidden;" *ngFor="let tab of tabs">
+    <mat-tab-group  #tabgroup class="code-tab-group" [class.avoid]="tabIsAvoid" disableRipple>
+      <mat-tab *ngFor="let tab of tabs">
         <ng-template mat-tab-label>
-          <span class="{{ tab.class }}">{{ tab.title }}</span>
+          <span class="{{ tab.class }}" [class.avoid]="tab.isAvoid">{{ tab.title }}</span>
         </ng-template>
+        <!--<pre>Debugging:\n{{tab.code}}</pre> -->
+        <!-- [code] binding needed because cannot project interpolation -->
         <aio-code class="{{ tab.class }}"
           [code]="tab.code"
+          [hideCopy]="tab.hideCopy"
           [language]="tab.language"
           [linenums]="tab.linenums"
           [path]="tab.path"
           [region]="tab.region"
           [title]="tab.title">
+          <!-- {{code.tabs}} sadly interpolation projection does not work! -->
         </aio-code>
       </mat-tab>
     </mat-tab-group>
+    <span #content style="display:none">
+      <ng-content></ng-content>
+    </span>
   `
 })
 export class CodeTabsComponent implements OnInit {
+  @ViewChild('content') contentRef: ElementRef;
+  @ViewChild('tabgroup') tabGroup: MatTabGroup;
+
+  tabIsAvoid = false;
   tabs: TabInfo[];
   linenumsDefault: string;
 
   constructor(private elementRef: ElementRef) { }
 
   ngOnInit() {
-    const element = this.elementRef.nativeElement;
-    this.linenumsDefault = this.getLinenums(element);
+    const hostElement = this.elementRef.nativeElement;
+    this.linenumsDefault = this.getLinenums(hostElement);
+
+    this.tabGroup.selectedIndexChange.subscribe(index => {
+      this.tabIsAvoid = this.tabs[index].isAvoid;
+    });
 
     // The `codeTabsContent` property is set by the DocViewer when it builds this component.
     // It is the original innerHTML of the host element.
-    const content = element.codeTabsContent;
-    this.processContent(content);
+    const content = hostElement.codeTabsContent;
+    this.processContent();
   }
 
-  processContent(content: string) {
-    // We add inner content to an element so that we can easily parse the HTML
-    const element = document.createElement('div');
-    // **Security:** `codeTabsContent` is provided by docs authors and as such is considered to
-    // be safe for innerHTML purposes.
-    element.innerHTML = content;
+  processContent() {
+    // **Security:** `codeTabsContent` is provided by docs authors and as such is considered to be safe for innerHTML purposes.
+    const content = this.contentRef.nativeElement;
+
 
     this.tabs = [];
-    const codeExamples = element.querySelectorAll('code-pane');
+    const codeExamples = content.querySelectorAll('code-pane');
+    this.contentRef.nativeElement.innerHTML = ''; // don't need it anymore
+
     for (let i = 0; i < codeExamples.length; i++) {
       const codeExample = codeExamples.item(i);
+
+      const path = codeExample.getAttribute('path') || '';
+      const isAvoid = (path || '').indexOf('.avoid.') !== -1;
+      const hideCopy = isAvoid || getBoolFromAttribute(codeExample, ['hidecopy', 'hide-copy']);
+
       const tab = {
         class: codeExample.getAttribute('class'),
         code: codeExample.innerHTML,
+        hideCopy,
+        isAvoid,
         language: codeExample.getAttribute('language'),
         linenums: this.getLinenums(codeExample),
-        path: codeExample.getAttribute('path') || '',
+        path: path,
         region: codeExample.getAttribute('region') || '',
         title: codeExample.getAttribute('title')
       };

--- a/src/docs/long-story.html
+++ b/src/docs/long-story.html
@@ -181,6 +181,14 @@ This page describes every embedded component in this project.
       getHeroes() { return of(HEROES); }
     }
   </code-pane>
+
+    <code-pane
+    path="bad.service.avoid.ts"
+    title="bad.service.ts">
+    export class BadService {
+      myBad() { return 'Oops. I forgot @Injectable().'; }
+    }
+  </code-pane>
 </code-tabs>
 <p>
   It's our most complex embedded component example and also derives from the

--- a/src/docs/tutorial/toh-intro.html
+++ b/src/docs/tutorial/toh-intro.html
@@ -1,18 +1,26 @@
 <h1 id="tutorial-tour-of-heroes">Tour of Heroes Tutorial</h1>
 
 <aside>
-The tutorial pages are excerpted from the Angular documentation tutorial.
+<p>Demonstrates both the <code>&ltcurrent-location></code> and the
+<code>&lt;awesome></code> components.</p>
+</aside>
+
 <p>
-This particular doc uses the embedded <code>CurrentLocationComponent</code>
-to determine that its location is
+The next paragraph shows the embedded <code>CurrentLocationComponent</code>
+to determine the document location after injecting the <i>application level</i>
+<code>Location</code><i> service</i>.
+
+<aside>
+<p>This document is located at
 <code>/docs/<current-location></current-location></code>.
 </p>
 </aside>
 
-<p>The grand plan for this tutorial is to build an app that helps a staffing agency manage its stable of heroes.
-</p>
 
-<aside>
+
+<p>Let's take the following paragraph from the Tour of Heroes ...</p>
+
+<aside class="outline">
   <p>
     The Tour of Heroes app covers the core fundamentals of Angular.
     You'll build a basic app that has many of the features
@@ -21,7 +29,7 @@ to determine that its location is
   </p>
 </aside>
 
-The previous paragraph is now manipulated by the embedded <code>AwesomeComponent</code>.
+... make it <i>awesome</i> with the embedded <code>AwesomeComponent</code>.
 
 <aside>
   <awesome>
@@ -34,8 +42,4 @@ The previous paragraph is now manipulated by the embedded <code>AwesomeComponent
 </aside>
 
 
-Back to normal prose.
-
-<p>You'll learn enough core Angular to get started and gain confidence that Angular can do whatever you need it to do. You'll
-  cover a lot of ground at an introductory level, and you'll find many links to pages with greater depth.
-</p>
+<p>That is truly awful. Back to normal prose.</p>

--- a/src/docs/tutorial/toh-pt1.html
+++ b/src/docs/tutorial/toh-pt1.html
@@ -24,6 +24,16 @@ export class AppComponent {
 }
 </code-example>
 
+<p>Don't forget the <code>export</code>!</p>
+<code-example
+  path="app.component.avoid.ts"
+  title="app.component.ts (Oops! Missing export)">
+  class AppComponent {
+    title = 'Tour of Heroes';
+    hero = 'Windstorm';
+  }
+</code-example>
+
 <h2 id="next-step">Next step</h2>
 <p>In the <a href="tutorial/toh-pt2" title="Master/Detail">next tutorial page</a>, you'll build on the Tour of Heroes app to display a list of heroes.
 You'll also allow the user to select heroes and display their details.</p>

--- a/src/docs/tutorial/toh-pt2.html
+++ b/src/docs/tutorial/toh-pt2.html
@@ -10,7 +10,7 @@ allow users to select a hero and display the hero's details.</p>
 <p>When you're done, the <code>AppComponent</code> looks like this.</p>
 
 <code-tabs>
-<code-pane title="app.component.ts">
+<code-pane title="app.component.ts" linenums="false">
   import { Component } from '@angular/core';
   import { Hero, HeroService } from './hero.service';
   import { Observable } from 'rxjs/Observable';
@@ -127,6 +127,14 @@ allow users to select a hero and display the hero's details.</p>
       getHeroes() {
         return of(HEROES);
       }
+    }
+  </code-pane>
+
+  <code-pane
+    path="bad.service.avoid.ts"
+    title="bad.service.ts">
+    export class BadService {
+      myBad() { return 'Oops. I forgot @Injectable().'; }
     }
   </code-pane>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -30,6 +30,10 @@ aside {
   padding: 10px;
 }
 
+aside.outline {
+  background-color: white;
+}
+
 button {
   font-family: Arial;
   background-color: #eee;
@@ -156,17 +160,19 @@ font-size: 16px;
 padding: 8px 16px;
 }
 
-code-example.avoid header,
-code-example.avoidFile header {
+code-example.avoid header {
 border: 2px solid #DD0031; /* $anti-pattern; */
 background: #DD0031 /* $anti-pattern; */
 }
 
-code-example.avoid,
-code-example.avoidFile,
-code-tabs.avoid mat-tab-body,
-code-tabs.avoidFile mat-tab-body {
-border: 0.5px solid #DD0031 /* $anti-pattern; */
+code-tabs mat-tab-group.avoid mat-tab-body.mat-tab-body-active {
+  border: 2px solid #DD0031; /* $anti-pattern; */
+  background: rgb(245, 195, 207) /* $anti-pattern; */
+
+}
+
+code-tabs span.avoid {
+  color: red;  /* $anti-pattern; */
 }
 
 code-tabs div .mat-tab-body-content {


### PR DESCRIPTION
Use projected content instead of hacky element property
remove references/usage of selectorToContentProperty
set properties with attributes in docviewer
clearer prose in the toh-intro.html
fix the `.avoid` class styling in code-tabs